### PR TITLE
Fix for llm 0.17

### DIFF
--- a/llm_azure.py
+++ b/llm_azure.py
@@ -96,7 +96,7 @@ class AzureChat(Chat):
             messages.append({"role": "system", "content": prompt.system})
         messages.append({"role": "user", "content": prompt.prompt})
         response._prompt_json = {"messages": messages}
-        kwargs = self.build_kwargs(prompt)
+        kwargs = self.build_kwargs(prompt, stream)
         client = self.get_client()
         if stream:
             completion = client.chat.completions.create(


### PR DESCRIPTION
`stream` is now a required argument to `Chat.build_kwargs()`

Before I was getting:
```console
$ llm "how long is some string"
Error: Chat.build_kwargs() missing 1 required positional argument: 'stream'
```

After:
```console
$ llm "how long is some string"
The length of a string can vary depending on the content or the specific string in question. If you provide the string you have in mind, I can help you determine its length!
```