### PR TITLE
Add attachments feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,17 @@ dirname "$(llm logs path)"
 ```
 
 The `model_id` is the name LLM will use for the model. The `deployment_name` is the name which needs to be passed to the API - this might differ from the `model_id`, especially if the `model_id` could potentially clash with other installed models.
+
+### Attachments
+
+To enable the `-a` flag, simply add an `attachment_types` section to your `config.yaml` with the desired filetypes (subject to the underlying model's support). Expanding on the example above, your `config.yaml` would now look like this:
+
+```yaml
+- model_id: gpt-4-32k
+  deployment_name: gpt-4-32k
+  endpoint: https://your_deployment.openai.azure.com/
+  api_version: '2023-05-15'
+  attachment_types:
+  - "image/png"
+  - "image/jpeg"
+```

--- a/llm_azure.py
+++ b/llm_azure.py
@@ -1,8 +1,9 @@
-from typing import Iterable, Iterator, List, Union
+from typing import Iterable, Iterator, List, Union, Optional
+from pathlib import Path
 
 import llm
 import yaml
-from llm import EmbeddingModel, hookimpl
+from llm import EmbeddingModel, hookimpl, Prompt, Response, Model
 from llm.default_plugins.openai_models import Chat, combine_chunks
 from llm.utils import remove_dict_none_values
 from openai import AzureOpenAI
@@ -11,32 +12,50 @@ from openai import AzureOpenAI
 @hookimpl
 def register_models(register):
     azure_path = config_dir() / "config.yaml"
+    if not azure_path.exists():
+        return
     with open(azure_path) as f:
         azure_models = yaml.safe_load(f)
-    for model in azure_models:
-        if not model.get('embedding_model'):
+    for model in azure_models or []:
+        if not model.get("embedding_model"):
             model_id = model["model_id"]
             model_name = model["deployment_name"]
             can_stream = model.get("can_stream", True)
             endpoint = model["endpoint"]
             api_version = model["api_version"]
             aliases = model.get("aliases", [])
-            register(AzureChat(model_id, model_name, can_stream, endpoint, api_version), aliases=aliases)
+            attachment_types = model.get("attachment_types")
+            register(
+                AzureChat(
+                    model_id,
+                    model_name,
+                    can_stream,
+                    endpoint,
+                    api_version,
+                    attachment_types,
+                ),
+                aliases=aliases,
+            )
 
 
 @hookimpl
 def register_embedding_models(register):
     azure_path = config_dir() / "config.yaml"
+    if not azure_path.exists():
+        return
     with open(azure_path) as f:
         azure_models = yaml.safe_load(f)
-    for model in azure_models:
-        if model.get('embedding_model'):
+    for model in azure_models or []:
+        if model.get("embedding_model"):
             model_id = model["model_id"]
             model_name = model["deployment_name"]
             endpoint = model["endpoint"]
             api_version = model["api_version"]
             aliases = model.get("aliases", [])
-            register(AzureEmbedding(model_id, model_name, endpoint, api_version), aliases=aliases)
+            register(
+                AzureEmbedding(model_id, model_name, endpoint, api_version),
+                aliases=aliases,
+            )
 
 
 class AzureEmbedding(EmbeddingModel):
@@ -64,12 +83,21 @@ class AzureChat(Chat):
     needs_key = "azure"
     key_env_var = "AZURE_OPENAI_API_KEY"
 
-    def __init__(self, model_id, model_name, can_stream, endpoint, api_version):
+    def __init__(
+        self,
+        model_id,
+        model_name,
+        can_stream,
+        endpoint,
+        api_version,
+        attachment_types=None,
+    ):
         self.model_id = model_id
         self.model_name = model_name
         self.can_stream = can_stream
         self.endpoint = endpoint
         self.api_version = api_version
+        self.attachment_types = attachment_types or set()
 
     def get_client(self):
         return _get_client(self)
@@ -80,26 +108,55 @@ class AzureChat(Chat):
     def execute(self, prompt, stream, response, conversation=None):
         messages = []
         current_system = None
+
+        # Handle conversation history and attachments
         if conversation is not None:
             for prev_response in conversation.responses:
-                if (
-                    prev_response.prompt.system
-                    and prev_response.prompt.system != current_system
-                ):
+                if prev_response.attachments:
+                    attachment_message = []
+                    if prev_response.prompt.prompt:
+                        attachment_message.append(
+                            {"type": "text", "text": prev_response.prompt.prompt}
+                        )
+                    for attachment in prev_response.attachments:
+                        attachment_message.append(_attachment(attachment))
+                    messages.append({"role": "user", "content": attachment_message})
+                else:
+                    if (
+                        prev_response.prompt.system
+                        and prev_response.prompt.system != current_system
+                    ):
+                        messages.append(
+                            {"role": "system", "content": prev_response.prompt.system},
+                        )
+                        current_system = prev_response.prompt.system
                     messages.append(
-                        {"role": "system", "content": prev_response.prompt.system},
+                        {"role": "user", "content": prev_response.prompt.prompt},
                     )
-                    current_system = prev_response.prompt.system
+
                 messages.append(
-                    {"role": "user", "content": prev_response.prompt.prompt},
+                    {"role": "assistant", "content": prev_response.text_or_raise()}
                 )
-                messages.append({"role": "assistant", "content": prev_response.text()})
+
+        # Handle system prompt
         if prompt.system and prompt.system != current_system:
             messages.append({"role": "system", "content": prompt.system})
-        messages.append({"role": "user", "content": prompt.prompt})
+
+        # Handle attachments for current prompt
+        if not prompt.attachments:
+            messages.append({"role": "user", "content": prompt.prompt})
+        else:
+            attachment_message = []
+            if prompt.prompt:
+                attachment_message.append({"type": "text", "text": prompt.prompt})
+            for attachment in prompt.attachments:
+                attachment_message.append(_attachment(attachment))
+            messages.append({"role": "user", "content": attachment_message})
+
         response._prompt_json = {"messages": messages}
         kwargs = self.build_kwargs(prompt, stream)
         client = self.get_client()
+
         if stream:
             completion = client.chat.completions.create(
                 model=self.model_name or self.model_id,
@@ -125,14 +182,14 @@ class AzureChat(Chat):
                 stream=False,
                 **kwargs,
             )
-            response.response_json = remove_dict_none_values(completion.dict())
+            response.response_json = remove_dict_none_values(completion.model_dump())
             yield completion.choices[0].message.content
 
 
 def config_dir():
     dir_path = llm.user_dir() / "azure"
     if not dir_path.exists():
-        dir_path.mkdir()
+        dir_path.mkdir(parents=True, exist_ok=True)
     return dir_path
 
 
@@ -142,3 +199,22 @@ def _get_client(self):
         api_version=self.api_version,
         azure_endpoint=self.endpoint,
     )
+
+
+def _attachment(attachment):
+    url = attachment.url
+    base64_content = ""
+    if not url or attachment.resolve_type().startswith("audio/"):
+        base64_content = attachment.base64_content()
+        url = f"data:{attachment.resolve_type()};base64,{base64_content}"
+    if attachment.resolve_type().startswith("image/"):
+        return {"type": "image_url", "image_url": {"url": url}}
+    else:
+        format_ = "wav" if attachment.resolve_type() == "audio/wav" else "mp3"
+        return {
+            "type": "input_audio",
+            "input_audio": {
+                "data": base64_content,
+                "format": format_,
+            },
+        }


### PR DESCRIPTION
The original `llm` implementation allows for the `-a` flag, which allows you to pass a file along with your prompts. This PR enables that feature for use with Azure models.

While this version supports audio (as it was written based off the Gemini implementation), the supported filetypes are subject to the base model being used in Azure.