### PR TITLE
Get key when constructing client

### DIFF
--- a/llm_azure.py
+++ b/llm_azure.py
@@ -137,6 +137,7 @@ def config_dir():
 
 
 def _get_client(self):
+    self.key = llm.get_key(None, self.needs_key, self.key_env_var)    
     return AzureOpenAI(
         api_key=self.key,
         api_version=self.api_version,


### PR DESCRIPTION
Fixes #11 

This PR is a tiny change to have the `_get_client` method set the model's key. Checking the `llm-claude-3` plugin (also written by Simon Willison), it appears [the convention for plugins is to call `self.get_key` when creating a new client](https://github.com/simonw/llm-claude-3/blob/8c08d567c5420e7f6fb05f7793a3394458b932e5/llm_claude_3.py#L248). This PR is a minimal change that brings this plugin in line with that convention.

