### PR TITLE
Add support for additional Azure model configuration parameters

### DIFF
--- a/example-config.yaml
+++ b/example-config.yaml
@@ -1,0 +1,23 @@
+# Vision-enabled model example
+- model_id: az-gpt-4o
+  deployment_name: gpt-4o
+  endpoint: "https://your-resource.openai.azure.com/"
+  api_version: "2025-01-01-preview"
+  aliases: ["az4o"]
+  vision: true
+
+# Audio-enabled model example
+- model_id: az-gpt-4o-audio
+  deployment_name: gpt-4o-audio-preview
+  endpoint: "https://your-resource.openai.azure.com/"
+  api_version: "2025-01-01-preview"
+  aliases: ["az4o-audio"]
+  audio: true
+
+# Reasoning model example
+- model_id: az-o3-mini
+  deployment_name: o3-mini
+  endpoint: "https://your-resource.openai.azure.com/"
+  api_version: "2025-01-01-preview"
+  aliases: ["azo3-mini"]
+  reasoning: true 

--- a/llm_azure.py
+++ b/llm_azure.py
@@ -21,7 +21,24 @@ def register_models(register):
             endpoint = model["endpoint"]
             api_version = model["api_version"]
             aliases = model.get("aliases", [])
-            register(AzureChat(model_id, model_name, can_stream, endpoint, api_version), aliases=aliases)
+            vision = model.get("vision", False)
+            audio = model.get("audio", False)
+            reasoning = model.get("reasoning", False)
+            allows_system_prompt = model.get("allows_system_prompt", True)
+            register(
+                AzureChat(
+                    model_id,
+                    model_name,
+                    can_stream,
+                    endpoint,
+                    api_version,
+                    vision=vision,
+                    audio=audio,
+                    reasoning=reasoning,
+                    allows_system_prompt=allows_system_prompt
+                ),
+                aliases=aliases
+            )
 
 
 @hookimpl
@@ -64,10 +81,16 @@ class AzureChat(Chat):
     needs_key = "azure"
     key_env_var = "AZURE_OPENAI_API_KEY"
 
-    def __init__(self, model_id, model_name, can_stream, endpoint, api_version):
-        self.model_id = model_id
-        self.model_name = model_name
-        self.can_stream = can_stream
+    def __init__(self, model_id, model_name, can_stream, endpoint, api_version, vision=False, audio=False, reasoning=False, allows_system_prompt=True):
+        super().__init__(
+            model_id,
+            model_name=model_name,
+            can_stream=can_stream,
+            vision=vision,
+            audio=audio,
+            reasoning=reasoning,
+            allows_system_prompt=allows_system_prompt
+        )
         self.endpoint = endpoint
         self.api_version = api_version
 


### PR DESCRIPTION
- Extend AzureChat initialization to support vision, audio, reasoning, and system prompt capabilities
- Update register_models function to pass new configuration options
- Modify AzureChat constructor to inherit from base Chat class with new parameters
- Add example-config.yaml demonstrating vision, audio, and reasoning model configurations