### PR TITLE
Add Azure CLI commands and ensure config file creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,16 @@ To add the `gpt-4-32k` chat model, and embedding model `text-embedding-3-small` 
 ```
 
 the configuration file should be in the `azure` directory in the config of your `llm` installation.
-Run this command to find the directory in which this file should be created:
+Run this command to find the location of the config file:
 
 ```bash
-dirname "$(llm logs path)"
+llm azure config-file
+```
+
+or you can open the file with:
+
+```bash
+open "$(llm azure config-file)"
 ```
 
 The `model_id` is the name LLM will use for the model. The `model_name` is the name which needs to be passed to the API - this might differ from the `model_id`, especially if `model_id` could potentially clash with other installed models.

--- a/llm_azure.py
+++ b/llm_azure.py
@@ -10,11 +10,12 @@ from openai import AsyncAzureOpenAI, AzureOpenAI
 
 
 def _ensure_config_file():
-    filepath = llm.user_dir() /  "azure" / "config.yaml"
+    filepath = llm.user_dir() / "azure" / "config.yaml"
     if not filepath.exists():
         filepath.parent.mkdir(exist_ok=True)
-        filepath.write_text('[]')
+        filepath.write_text("[]")
     return filepath
+
 
 @llm.hookimpl
 def register_commands(cli):
@@ -26,6 +27,7 @@ def register_commands(cli):
     def config_file():
         "Display the path to the azure config file"
         click.echo(_ensure_config_file())
+
 
 @hookimpl
 def register_models(register):

--- a/llm_azure.py
+++ b/llm_azure.py
@@ -1,6 +1,7 @@
 import os
 from typing import Iterable, Iterator, List, Union
 
+import click
 import llm
 import yaml
 from llm import EmbeddingModel, hookimpl
@@ -8,12 +9,27 @@ from llm.default_plugins.openai_models import AsyncChat, Chat, _Shared, not_null
 from openai import AsyncAzureOpenAI, AzureOpenAI
 
 
+def _ensure_config_file():
+    filepath = llm.user_dir() /  "azure" / "config.yaml"
+    if not filepath.exists():
+        filepath.parent.mkdir(exist_ok=True)
+        filepath.write_text('[]')
+    return filepath
+
+@llm.hookimpl
+def register_commands(cli):
+    @cli.group()
+    def azure():
+        "Commands for working with azure models"
+
+    @azure.command()
+    def config_file():
+        "Display the path to the azure config file"
+        click.echo(_ensure_config_file())
+
 @hookimpl
 def register_models(register):
-    azure_path = llm.user_dir() / "azure"
-    azure_path.mkdir(exist_ok=True)
-    azure_path = azure_path / "config.yaml"
-
+    azure_path = _ensure_config_file()
     with open(azure_path) as f:
         azure_models = yaml.safe_load(f)
 
@@ -32,10 +48,7 @@ def register_models(register):
 
 @hookimpl
 def register_embedding_models(register):
-    azure_path = llm.user_dir() / "azure"
-    azure_path.mkdir(exist_ok=True)
-    azure_path = azure_path / "config.yaml"
-
+    azure_path = _ensure_config_file()
     with open(azure_path) as f:
         azure_models = yaml.safe_load(f)
 


### PR DESCRIPTION
closes #15 

1.	Ensure Config File Exists
Automatically creates a YAML configuration file with an empty list if the file does not exist, ensuring the presence of a valid config file to avoid errors for initial setup.
2.	New Command Addition
Introduces the `llm azure config-path` command, which displays the path to the configuration file.

on my macbook running a new command:
```
❯ llm azure config-file
/Users/kh03/Library/Application Support/io.datasette.llm/azure/config.yaml
```

following opens up a config file for me:
```
❯ open "$(llm azure config-file)"
```