### PR TITLE
improve onboarding config workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,16 @@ llm keys set azure
 To add the `gpt-4-32k` chat model, and embedding model `text-embedding-3-small` deployed in your Azure Subscription, add this to your `azure/config.yaml` file:
 
 ```yaml
-- model_id: gpt-4-32k
-  model_name: gpt-4-32k
-  api_base: https://your_deployment.openai.azure.com/
-  api_version: '2023-05-15'
+- model_id: azure-gpt-5-mini
+  model_name: gpt-5-mini
+  api_base: https://your_deployment.cognitiveservices.azure.com/
+  api_version: '2024-12-01-preview'
 
 - model_id: text-embedding-3-small
   embedding_model: true
   model_name: text-embedding-3-small
   api_base: https://your_deployment.openai.azure.com/
-  api_version: '2023-05-14'
+  api_version: "2024-02-01"
 ```
 
 the configuration file should be in the `azure` directory in the config of your `llm` installation.
@@ -45,4 +45,12 @@ Run this command to find the directory in which this file should be created:
 dirname "$(llm logs path)"
 ```
 
-The `model_id` is the name LLM will use for the model. The `model_name` is the name which needs to be passed to the API - this might differ from the `model_id`, especially if `model_id` could potentially clash with other installed models.
+- The `model_id` is the name `llm` library will use to refer to the model.
+- The `model_name` is the name which needs to be passed to the API - this might differ from the `model_id`, especially if `model_id` could potentially clash with other installed models.
+- The `endpoint` and `api_version` are provided in Azure AI Deployment's sample code snippets
+
+```sh
+llm -m azure-gpt-5-mini "tell me more about how to use the llm python library to call azure endpoints using the llm-azure library"
+
+llm embed -m text-embedding-3-small -c "this is how you use embedding - the output is an array of floats"
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llm-azure"
-version = "1.1"
+version = "1.2"
 description = "Azure plugin for LLM using the AzureOpenAI class"
 readme = "README.md"
 authors = [{name = "Fabian Geiger"}]


### PR DESCRIPTION
# Improvement

- Improve the first time use onboarding workflow by initializing the config file at the expected location with the placeholders from README example
- During first usage, the user now sees:

```
Your Azure config file needs to be initialized with your deployment values. Find yours at https://ai.azure.com
Hint: Open '/Users/username/Library/Application Support/io.datasette.llm/azure/config.yaml' in your editor to update your deployment details.
```

# Testing

Installed locally with `llm install -e <my repo path>`

I tested with my personal endpoints, like the example config, only replacing `endpoint` value with my own. Both the chat and embedding models work as expected.