### PR TITLE
Add attachment and schema support for AzureOpenAIChat models

### DIFF
--- a/llm_azure/__init__.py
+++ b/llm_azure/__init__.py
@@ -51,6 +51,7 @@ def register_models(register):
                     model_name=model["model_name"],
                     endpoint=model["endpoint"],
                     api_key_name=model.get("api_key_name"),
+                    supports_images=model.get("supports_images", True),
                 ),
                 aliases=aliases,
             )

--- a/llm_azure/openai.py
+++ b/llm_azure/openai.py
@@ -64,11 +64,13 @@ class AzureOpenAIChat(AzureOpenAIShared, Chat):
             endpoint=endpoint,
             api_key_name=api_key_name,
         )
-        # Initialize Chat
+        # Initialize Chat with schema support
         Chat.__init__(
             self,
             model_id=model_id,
             model_name=model_name,
+            supports_schema=True,
+            supports_tools=True,
         )
         # Set attachment types for vision support
         if supports_images:

--- a/llm_azure/openai.py
+++ b/llm_azure/openai.py
@@ -48,4 +48,34 @@ class AzureOpenAIShared(_Shared):
 class AzureOpenAIChat(AzureOpenAIShared, Chat):
     """Chat model for OpenAI models on Azure AI Foundry with Entra ID auth."""
 
-    pass
+    def __init__(
+        self,
+        model_id: str,
+        model_name: str,
+        endpoint: str,
+        api_key_name: str | None = None,
+        supports_images: bool = True,
+    ):
+        # Initialize shared functionality
+        AzureOpenAIShared.__init__(
+            self,
+            model_id=model_id,
+            model_name=model_name,
+            endpoint=endpoint,
+            api_key_name=api_key_name,
+        )
+        # Initialize Chat
+        Chat.__init__(
+            self,
+            model_id=model_id,
+            model_name=model_name,
+        )
+        # Set attachment types for vision support
+        if supports_images:
+            self.attachment_types = {
+                "image/png",
+                "image/jpeg",
+                "image/webp",
+                "image/gif",
+                "application/pdf",
+            }


### PR DESCRIPTION
Enable AzureOpenAIChat models to support attachments and structured output via JSON schemas.

**Features added:**
- Add `supports_images` flag to model registration (default: True)
- Enable attachment types (image/PNG, JPEG, WebP, GIF, PDF) when vision is supported
- Enable schema support for structured JSON output
- Enable tools support for function calling

**Attachment support**

Before:
```
➜ llm --attachment ~/Downloads/gpt-5-pelican.png \
  --system "You are an expert nature photography analyst." \
  --option temperature 0.1 \
  "Does this image contain a pelican?"
Error: This model does not support attachments
```

After:
```
llm --attachment ~/Downloads/gpt-5-pelican.png \
  --system "You are an expert nature photography analyst." \
  --option temperature 0.1 \
  "Does this image contain a pelican?"
Yes. The image shows a cartoon pelican riding a bicycle.
```

**Schema support**

Before:
```
➜ llm --schema 'contains_pelican bool' "Does this image contain a pelican?"
Error: OpenAI Chat: does not support schemas
```

After:
```
llm --attachment ~/Downloads/gpt-5-pelican.png \
  --system "You are a nature photography expert." \
  --option temperature 0.1 \
  --schema 'contains_pelican bool' \
  "Does this image contain a pelican?"
{"contains_pelican":true}
```

Test case:

<img width="800" height="600" alt="gpt-5-pelican" src="https://github.com/user-attachments/assets/d01b9e93-e241-4809-8ecf-718be4abd7e0"/>